### PR TITLE
Allowing for searchAlleles to not specify a sequence or interval

### DIFF
--- a/src/main/resources/avro/variantmethods.avdl
+++ b/src/main/resources/avro/variantmethods.avdl
@@ -167,24 +167,33 @@ record SearchAllelesRequest {
   array<string> variantSetIds = [];
 
   /**
-  Required. Only return `Allele`s on the sequence with this ID.
-   */
-  string sequenceId;
+  If not null, only return `Allele`s on the sequence with this ID. If null,
+  return `Allele`s on all `Sequence`s in the `VariantSet` and its
+  `ReferenceSet`.
+  */
+  union { null, string } sequenceId = null;
 
   /**
-  Required. The beginning of the window (0-based, inclusive) for
-  which overlapping alleles should be returned.
-  Genomic positions are non-negative integers less than segment length.
+  If not null, return only `Allele`s overlapping the window between here
+  (inclusive) and end (exclusive) on the sequence given by sequenceId. If not
+  null, sequenceId and end must not be null.
+
+  Genomic positions are non-negative integers less than sequence length.
   Requests spanning the join of circular genomes are represented as
   two requests one on each side of the join (position 0).
   */
-  long start;
+  union { null, long } start = null;
 
   /**
-  Required. The end of the window (0-based, exclusive) for which overlapping
-  alleles should be returned.
+  If not null, return only `Allele`s overlapping the window between start
+  (inclusive) and here (exclusive) on the sequence given by sequenceId. If not
+  null, sequenceId and start must not be null.
+
+  Genomic positions are non-negative integers less than sequence length.
+  Requests spanning the join of circular genomes are represented as
+  two requests one on each side of the join (position 0).
   */
-  long end;
+  union { null, long } end = null;
 
   /**
   Specifies the maximum number of results to return in a single page.

--- a/src/main/resources/avro/variants.avdl
+++ b/src/main/resources/avro/variants.avdl
@@ -383,6 +383,9 @@ record Allele {
   /** The ID of the variant set this allele belongs to. */
   string variantSetId;
 
+  /** Optional name for the Allele */
+  union { null, string } name = null;
+
   /**
   The ordered and oriented `Segment`s of DNA that this `Allele` represents.
 


### PR DESCRIPTION
This makes it possible to easily enumerate alleles, by enumerating variantsets and then the alleles in them.
